### PR TITLE
Updating MtHaml Lexer.php to support twig 1.27+

### DIFF
--- a/src/SilexMtHaml/Lexer.php
+++ b/src/SilexMtHaml/Lexer.php
@@ -18,17 +18,31 @@ class Lexer implements \Twig_LexerInterface
 
     public function tokenize($code, $filename = null)
     {
-        if ($code instanceof Twig_Source) {
+        if ($source instanceof Twig_Source) {
+            $code = $source->getCode();
             if ($filename === null) {
-                $filename = $code->getName();
+                $filename = $source->getName();
             }
-            $code = $code->getCode();
+            $path = $source->getPath();
+    
+            if (null !== $filename && (preg_match('/\.haml$/', $filename))) {
+                $code = $this->environment->compileString($code, $filename);
+            }
+            
+            $new_source = new Twig_Source($code, $filename, $path);
+            
+            return $this->lexer->tokenize($new_source);
         }
-        
-        if (null !== $filename && preg_match('/\.haml$/', $filename)) {
-            $code = $this->environment->compileString($code, $filename);
+        else {
+            $code = $source;
+            
+            if (null !== $filename && (preg_match('/\.haml$/', $filename))) {
+                $code = $this->environment->compileString($code, $filename);
+            }
+
+            return $this->lexer->tokenize($code, $filename);
         }
-        return $this->lexer->tokenize($code, $filename);
     }
+
 }
 

--- a/src/SilexMtHaml/Lexer.php
+++ b/src/SilexMtHaml/Lexer.php
@@ -19,8 +19,9 @@ class Lexer implements \Twig_LexerInterface
     public function tokenize($code, $filename = null)
     {
         if ($code instanceof Twig_Source) {
-            if ($filename === null)
+            if ($filename === null) {
                 $filename = $code->getName();
+            }
             $code = $code->getCode();
         }
         

--- a/src/SilexMtHaml/Lexer.php
+++ b/src/SilexMtHaml/Lexer.php
@@ -3,6 +3,7 @@
 namespace SilexMtHaml;
 
 use MtHaml\Environment;
+use \Twig_Source;
 
 class Lexer implements \Twig_LexerInterface
 {
@@ -17,6 +18,12 @@ class Lexer implements \Twig_LexerInterface
 
     public function tokenize($code, $filename = null)
     {
+        if ($code instanceof Twig_Source) {
+            if ($filename === null)
+                $filename = $code->getName();
+            $code = $code->getCode();
+        }
+        
         if (null !== $filename && preg_match('/\.haml$/', $filename)) {
             $code = $this->environment->compileString($code, $filename);
         }


### PR DESCRIPTION
Also the final part should look like this:

```php
$source = new Twig_Source($code, $filename);
return $this->lexer->tokenize($source);
```
Because, of deprecation [here](https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Lexer.php#L81)